### PR TITLE
Fixed deployment after new hook checkDb is added.

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,5 +17,8 @@ module.exports = {
 	},
 	parserOptions: {
 		"ecmaVersion": 15
-	}
+	},
+	ignorePatterns: [
+		'checkDb.js'
+	]
 }

--- a/public/checkDb.js
+++ b/public/checkDb.js
@@ -1,4 +1,4 @@
-import data from './db.json'  assert { type: 'json' };
+import data from './db.json' assert { type: 'json' };
 
 /**
  * @param services {{id: string, name: string}[]} List of services to check the uniqueness by id field


### PR DESCRIPTION
Output of `npm run lint` :

`
> aiacatalog@0.0.0 lint
> eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore


/.../aia-catalog/src/components/search/AutoComplete.vue
  54:15  warning  The "item-selected" event has been triggered but not declared on `emits` option  vue/require-explicit-emits
  95:5   warning  'v-html' directive can lead to XSS attack                                        vue/no-v-html

✖ 2 problems (0 errors, 2 warnings)

`